### PR TITLE
Add missing cd step + use git option + https to refer gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
 #gem 'rails', path: "/Users/eileen/Sites/open_source/rails"
-gem 'rails', github: 'eileencodes/rails', branch: 'rails_system_tests'
+gem 'rails', git: 'https://github.com/eileencodes/rails.git', branch: 'rails_system_tests'
 
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets
-gem 'sass-rails', github: "rails/sass-rails"
+gem 'sass-rails', git: "https://github.com/rails/sass-rails.git"
 
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
@@ -38,7 +38,7 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'web-console', github: 'rails/web-console'
+  gem 'web-console', git: 'https://github.com/rails/web-console.git'
   gem 'listen', '~> 3.0.5'
 end
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ To run the system tests:
 ```
 git clone git@github.com:eileencodes/system_testing_app.git
 
+cd system_testing_app
+
 bundle
 
 bin/rails db:create


### PR DESCRIPTION
This PR:
- Add a missing `cd` step
- Use `git` option w/ https git url so that bundler won't emit these warnings:
  
  ```
  The git source `git://github.com/eileencodes/rails.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
  The git source `git://github.com/rails/sass-rails.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
  The git source `git://github.com/rails/web-console.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
  ```
## 

Amazing work!!!!!!! 🎉 😊
